### PR TITLE
Main Page 동영상 문제 해결

### DIFF
--- a/frontend/src/custom.d.ts
+++ b/frontend/src/custom.d.ts
@@ -1,0 +1,4 @@
+declare module '*.mp4' {
+    const src: string;
+    export default src;
+}

--- a/frontend/src/pages/main.tsx
+++ b/frontend/src/pages/main.tsx
@@ -10,7 +10,7 @@ export default function Main() {
       <Carousel fade>
       <Carousel.Item interval={30000} className='itemcA1'>
           <a href="#/회사소개/회사정보">
-            <video width="100%" autoPlay>
+            <video width="100%" autoPlay muted>
               <source src={civideo} type="video/mp4"/>
             </video>
             <Carousel.Caption>


### PR DESCRIPTION
- TypeScript가 수행하는 strict checking을 만족하기 위해 `.mp4` file을 module로 인식하도록 설정
  - Video가 정상적으로 import되는 것을 확인
  - Main page에서 비디오가 정지된 상태로 load되고 다른 page 방문 후 돌아올 경우에만 재생 되는 문제가 있었음
- 위 문제를 해결하기 위해 `muted` 속성 추가
  - 해당 문제는 Google Chrome을 사용 시 나타나는 문제입니다. 다음을 확인하세요: https://developer.chrome.com/blog/autoplay 